### PR TITLE
Use canonical order of rooms as exit options

### DIFF
--- a/editor/shared/script/editor.js
+++ b/editor/shared/script/editor.js
@@ -2067,7 +2067,9 @@ function updateExitOptionsFromGameData() {
 	}
 
 	// then, add an option for each room
-	for (roomId in room) {
+	var roomIds = sortedRoomIdList();
+	for (var j = 0; j < roomIds.length; j++) {
+		var roomId = roomIds[j];
 		var option = document.createElement("option");
 		if(room[roomId].name != null)
 			option.text = room[roomId].name;


### PR DESCRIPTION
From commit message:
> Previously the exit options would be sorted by the `room` object's
key iteration order. That iteration order is arbitrary
(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in)
so for games with lots of rooms, it can be really inconvenient to
have to search though an unpredictable list of room names for the
one you want. This instead uses the order of rooms that correspond
to moving forward/backward through the room selector card.

The game I'm working on has a ton of rooms, and I noticed that as I was working on it the list of rooms in the exit editor would occasionally shuffle. It was still mostly sorted, and every room was represented, but there would be weird skips. I decided to investigate a little bit, and saw that the order is based strictly on the browser's object property iteration order, which doesn't have any guarantees. It makes sense to me to utilize the room order that already exists in the room editor.

List after change:
<img width="173" alt="screen shot 2018-11-30 at 8 38 04 pm" src="https://user-images.githubusercontent.com/155113/49324331-532b5300-f4e0-11e8-93d2-d111284e6e62.png">

List before change:
<img width="148" alt="screen shot 2018-11-30 at 8 39 37 pm" src="https://user-images.githubusercontent.com/155113/49324332-54f51680-f4e0-11e8-9f97-9e6efbd9d8a9.png">

While nothing in those pictures necessarily looks out of place, I promise you the order after the change is the non-confusing one. 

Rooms are appended to the `select` element as rooms are created already, which happens to conform with the canonical room order anyway, so the only change necessary is these few lines.
