### PR TITLE
make Firefox use nearest-neighbour image scaling for the "find drawing" window

### DIFF
--- a/editor/shared/style/editorStyle.css
+++ b/editor/shared/style/editorStyle.css
@@ -268,6 +268,7 @@ input {
 	margin-bottom:-6px; /* should be unnecesarry really */
 	display:inline-block;
 	image-rendering: pixelated;
+	image-rendering: -moz-crisp-edges;
 	border: solid 4px white;
 	/*border: none;*/
 }


### PR DESCRIPTION
…instead of the current (blurry) bicubic mode.

should still fall back to 'pixelated' for non-mozilla browsers.