### PR TITLE
Added background for editor window when in play mode

### DIFF
--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -22,6 +22,9 @@ new notes from forum
 */
 
 /* MODES */
+const PLAY_MODE = "play";
+const EDIT_MODE = "edit";
+
 var TileType = {
 	Tile : 0,
 	Sprite : 1,
@@ -1631,6 +1634,7 @@ function on_edit_mode() {
 		}
 	}
 	document.getElementById("previewDialogCheck").disabled = false;
+	updateEditorWindowByMode(EDIT_MODE);
 }
 
 // hacky - part of hiding font data from the game data
@@ -1652,6 +1656,17 @@ function on_play_mode() {
 		console.log("DISALBE PREVIEW!!!");
 		document.getElementById("previewDialogCheck").disabled = true;
 	}
+	updateEditorWindowByMode(PLAY_MODE);
+}
+
+function updateEditorWindowByMode(mode) {
+	const playModeClassAction = (mode === PLAY_MODE) ? "add" : "remove";
+	updateEditorWindowClasses(playModeClassAction, "playMode");
+}
+
+function updateEditorWindowClasses(action, className) {
+	const editorWindow = document.getElementById("editorWindow");
+	editorWindow.classList[action](className);
 }
 
 function updatePlayModeButton() {

--- a/editor/style/editorColors.css
+++ b/editor/style/editorColors.css
@@ -172,3 +172,14 @@ button:disabled {
 	background: #6767b2;
 	color:white;
 }
+
+.playMode {
+	background-color: rgba(0,0,0,0.5);
+	background-image: repeating-linear-gradient(
+		45deg,
+		rgba(0,0,0,0),
+		rgba(0,0,0,0) 15px,
+		rgba(0,0,0,0.03) 15px,
+		rgba(0,0,0,0.03) 30px
+	);
+}

--- a/editor/style/editorStyle.css
+++ b/editor/style/editorStyle.css
@@ -50,16 +50,14 @@ input[type=text] {
 #editorWindow {
 	width:100%;
 	/*height:750px;*/
-
 	overflow:scroll;
 	-webkit-overflow-scrolling: touch;
-
 	box-sizing: border-box;
-
 	flex: 1 1 auto;
-
+	transition: all 0.7s ease-in-out;
 	/*border: solid 2px red;*/
 }
+
 #editorContent {
 	height:100%;
 	white-space: nowrap;


### PR DESCRIPTION
When going into "play" mode, the editor will now add a shaded background. This should being to address problems such as https://github.com/le-doux/bitsy/issues/28 by making it more clear to users which mode they're in so that they don't try to make edits.