### PR TITLE
fixed "unable to preventDefault inside passive event listener," bug

### DIFF
--- a/editor/script/engine/bitsy.js
+++ b/editor/script/engine/bitsy.js
@@ -229,14 +229,14 @@ function onready(startWithTitle) {
 	document.addEventListener('keyup', input.onkeyup);
 
 	if (isPlayerEmbeddedInEditor) {
-		canvas.addEventListener('touchstart', input.ontouchstart);
-		canvas.addEventListener('touchmove', input.ontouchmove);
-		canvas.addEventListener('touchend', input.ontouchend);
+		canvas.addEventListener('touchstart', input.ontouchstart, {passive:false});
+		canvas.addEventListener('touchmove', input.ontouchmove, {passive:false});
+		canvas.addEventListener('touchend', input.ontouchend, {passive:false});
 	}
 	else {
-		document.addEventListener('touchstart', input.ontouchstart);
-		document.addEventListener('touchmove', input.ontouchmove);
-		document.addEventListener('touchend', input.ontouchend);
+		document.addEventListener('touchstart', input.ontouchstart, {passive:false});
+		document.addEventListener('touchmove', input.ontouchmove, {passive:false});
+		document.addEventListener('touchend', input.ontouchend, {passive:false});
 	}
 
 	window.onblur = input.onblur;


### PR DESCRIPTION
fixes #46 

Makes Chrome happy and not throw the "unable to preventDefault inside passive event listener," message every frame on touch input