### PR TITLE
fix: transition `SetPixelColor` scale math

### DIFF
--- a/editor/script/engine/transition.js
+++ b/editor/script/engine/transition.js
@@ -396,8 +396,8 @@ var PostProcessUtilities = {
 		return { r:r, g:g, b:b, a:a };
 	},
 	SetPixelColor : function(image,x,y,colorRgba) {
-		for (var yDelta = 0; yDelta <= scale; yDelta++) {
-			for (var xDelta = 0; xDelta <= scale; xDelta++) {
+		for (var yDelta = 0; yDelta < scale; yDelta++) {
+			for (var xDelta = 0; xDelta < scale; xDelta++) {
 				var pixelIndex = (((y * scale) + yDelta) * image.width * 4) + (((x * scale) + xDelta) * 4);
 				image.data[pixelIndex + 0] = colorRgba.r;
 				image.data[pixelIndex + 1] = colorRgba.g;


### PR DESCRIPTION
loops for handling scale were 0-`scale` *inclusive*, which meant that they were always going one iteration further than intended (the reason this was most visible on the edges is that colours from one side would wrap around to the other as they overflowed a row of pixels)

fixes #102