### PR TITLE
#47 - Preserve native methods when handling touch events

### DIFF
--- a/editor/script/color_picker.js
+++ b/editor/script/color_picker.js
@@ -216,14 +216,20 @@ function ColorPicker( wheelId, selectId, sliderId, sliderBgId, hexTextId ) {
 
 		if (isMouseDown) {
 			e.preventDefault();
-			pickColor(e.touches[0], false);
+			// update event to translate from touch-style to mouse-style structure
+			e.clientX = e.touches[0].clientX;
+			e.clientY = e.touches[0].clientY;
+			pickColor(e, false);
 		}
 	}
 
 	function pickColorTouchStart(e) {
 		// console.log(e.touches[0]);
 		e.preventDefault();
-		pickColorStart(e.touches[0]);
+		// update event to translate from touch-style to mouse-style structure
+		e.clientX = e.touches[0].clientX;
+		e.clientY = e.touches[0].clientY;
+		pickColorStart(e);
 	}
 
 	function pickColorTouchEnd(e) {
@@ -289,13 +295,19 @@ function ColorPicker( wheelId, selectId, sliderId, sliderBgId, hexTextId ) {
 	function pickValueTouchMove(e) {
 		if (isSliderMouseDown) {
 			e.preventDefault();
-			pickValue(e.touches[0], false);
+			// update event to translate from touch-style to mouse-style structure
+			e.clientX = e.touches[0].clientX;
+			e.clientY = e.touches[0].clientY;
+			pickValue(e, false);
 		}
 	}
 
 	function pickValueTouchStart(e) {
 		e.preventDefault();
-		pickValueStart(e.touches[0]);
+		// update event to translate from touch-style to mouse-style structure
+		e.clientX = e.touches[0].clientX;
+		e.clientY = e.touches[0].clientY;
+		pickValueStart(e);
 	}
 
 	function pickValueTouchEnd(e) {

--- a/editor/script/paint.js
+++ b/editor/script/paint.js
@@ -202,14 +202,18 @@ function PaintTool(canvas, roomTool) {
 
 	function onTouchStart(e) {
 		e.preventDefault();
-		var fakeEvent = { target:e.target, clientX:e.touches[0].clientX, clientY:e.touches[0].clientY };
-		onMouseDown(fakeEvent);
+		// update event to translate from touch-style to mouse-style structure
+		e.clientX = e.touches[0].clientX;
+		e.clientY = e.touches[0].clientY;
+		onMouseDown(e);
 	}
 
 	function onTouchMove(e) {
 		e.preventDefault();
-		var fakeEvent = { target:e.target, clientX:e.touches[0].clientX, clientY:e.touches[0].clientY };
-		onMouseMove(fakeEvent);
+		// update event to translate from touch-style to mouse-style structure
+		e.clientX = e.touches[0].clientX;
+		e.clientY = e.touches[0].clientY;
+		onMouseMove(e);
 	}
 
 	function onTouchEnd(e) {

--- a/editor/script/room.js
+++ b/editor/script/room.js
@@ -199,16 +199,18 @@ function RoomTool(canvas) {
 
 	function onTouchStart(e) {
 		e.preventDefault();
-		// console.log(e.touches[0]);
-		var fakeEvent = { target:e.target, clientX:e.touches[0].clientX, clientY:e.touches[0].clientY };
-		// console.log(fakeEvent);
-		onMouseDown( fakeEvent );
+		// update event to translate from touch-style to mouse-style structure
+		e.clientX = e.touches[0].clientX;
+		e.clientY = e.touches[0].clientY;
+		onMouseDown( e );
 	}
 
 	function onTouchMove(e) {
 		e.preventDefault();
-		var fakeEvent = { target:e.target, clientX:e.touches[0].clientX, clientY:e.touches[0].clientY };
-		onMouseMove( fakeEvent );
+		// update event to translate from touch-style to mouse-style structure
+		e.clientX = e.touches[0].clientX;
+		e.clientY = e.touches[0].clientY;
+		onMouseMove( e );
 	}
 
 	function onTouchEnd(e) {


### PR DESCRIPTION
Hello! This code should fix #47. 🥸

The bug is occurring because the "middleman" functions for handling touch events were passing in the position info about the touch itself - `clientX` and `clientY` - but didn't include the rest of the event data (like prototype method `preventDefault()`) as the click handlers expected, causing errors and preventing touch events from working in a few of the Editor panels.

With my update, we simply restructure the top-level event object `e` to include the expected mouse-style `clientX` and `clientY` values while still retaining the rest of the event prototype data. Touch events behave like click events and the code is happy once again. Pretty sure I found all the instances of this bug, but if I missed one or two the same fix should apply!

(Tested on an iPad Pro running iPadOS 14.4 and an iPhone running iOS 14.4.)