### PR TITLE
fix: unrecoverable state due to localization issues

### DIFF
--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -164,8 +164,8 @@ function getStringOrFallback(id, englishFallback) {
 
 	var locString = getString(id);
 	if(!locString) {
-		locString = englishFallback || id;
-		unlocalizedDynamicStrings[id] = englishFallback; // record use of unlocalized strings
+		locString =  getLocaleString(defaultLanguage, id) || englishFallback || id;
+		unlocalizedDynamicStrings[id] = locString; // record use of unlocalized strings
 	}
 	return locString;
 }

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -159,7 +159,7 @@ function getStringOrFallback(id, englishFallback) {
 		return englishFallback;
 
 	var locString = getString(id);
-	if(locString == null || locString.length <= 0) {
+	if(!locString) {
 		locString = englishFallback;
 		unlocalizedDynamicStrings[id] = englishFallback; // record use of unlocalized strings
 	}

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -143,7 +143,8 @@ this.ChangeLanguage = function(newLanguage) {
 }
 
 function getString(id) {
-	return localizationStrings[getEditorLanguage()][id];
+	var langStrings = localizationStrings[getEditorLanguage()];
+	return langStrings && langStrings[id];
 }
 this.GetString = function(id) {
 	return getString(id);

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -23,6 +23,8 @@ var localizationStrings = null;
 
 var currentLanguage;
 
+var defaultLanguage = "en";
+
 var initialize = function() { // why does this happen multiple times?
 	var csv = Resources["localization.tsv"];
 	// console.log(csv);
@@ -86,8 +88,8 @@ function localize(language) {
 		if (locString) {
 			el.innerText = locString;
 		}
-		else if (localizationStrings["en"][localizationId] != null) {
-			el.innerText = localizationStrings["en"][localizationId]; // fall back to english
+		else if (localizationStrings[defaultLanguage][localizationId] != null) {
+			el.innerText = localizationStrings[defaultLanguage][localizationId]; // fall back to english
 		}
 	}
 }
@@ -103,7 +105,7 @@ function getEditorLanguage() {
 
 	// fallback to english
 	if(!localizationStrings[language]) {
-		language = "en";
+		language = defaultLanguage;
 	}
 
 	return language;
@@ -206,7 +208,7 @@ this.ExportMissingEnglishStrings = function() {
 	for(var i = 0; i < elements.length; i++) {
 		var el = elements[i];
 		var localizationId = getLocalizationId(el);
-		if(!localizationStrings["en"][localizationId])
+		if(!localizationStrings[defaultLanguage][localizationId])
 			englishStrings[localizationId] = el.innerText;
 	}
 	exportEnglishStringsDictionary(englishStrings);

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -21,6 +21,8 @@ var self = this;
 
 var localizationStrings = null;
 
+var currentLanguage;
+
 var initialize = function() { // why does this happen multiple times?
 	var csv = Resources["localization.tsv"];
 	// console.log(csv);
@@ -49,6 +51,8 @@ var initialize = function() { // why does this happen multiple times?
 			localizationStrings[languageId][lineId] = lineSplit[j]; // TOOD - protect against empty lines
 		}
 	}
+
+	currentLanguage = localStorage.editor_language;
 
 	// console.log(localizationStrings);
 	// localize( getEditorLanguage() );
@@ -92,17 +96,17 @@ this.Localize = function() {
 }
 
 function getEditorLanguage() {
-	if(localStorage.editor_language == null) {
-		var browserLanguage = (navigator.languages ? navigator.languages[0] : navigator.language).split("-")[0];
-		localStorage.editor_language = browserLanguage;
+	var language = currentLanguage;
+	if(!language) {
+		language = (navigator.languages ? navigator.languages[0] : navigator.language).split("-")[0];
 	}
 
 	// fallback to english
-	if(localizationStrings[localStorage.editor_language] == null) {
-		localStorage.editor_language = "en";
+	if(!localizationStrings[language]) {
+		language = "en";
 	}
 
-	return localStorage.editor_language;
+	return language;
 }
 this.GetLanguage = function() {
 	return getEditorLanguage();
@@ -131,8 +135,10 @@ this.GetLanguageList = function() {
 	return getLanguageList();
 }
 
-this.ChangeLanguage = function(language) {
-	saveEditorLanguage(language);
+this.ChangeLanguage = function(newLanguage) {
+	currentLanguage = newLanguage;
+	currentLanguage = getEditorLanguage();
+	saveEditorLanguage(currentLanguage);
 	localize( getEditorLanguage() );
 }
 

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -74,6 +74,11 @@ function getLocalizationId(element) { // the localization id is the class AFTER 
 	return null; // oops
 }
 
+function getLocaleString(locale, id) {
+	var localeStrings = localizationStrings[locale];
+	return localeStrings && localeStrings[id];
+}
+
 function localize(language) {
 	if(localizationStrings == null)
 		return;
@@ -84,12 +89,12 @@ function localize(language) {
 	for(var i = 0; i < elements.length; i++) {
 		var el = elements[i];
 		var localizationId = getLocalizationId(el);
-		var locString = localizationStrings[language][localizationId];
+		var locString = getLocaleString(language, localizationId);
+		if (!locString) {
+			locString = getLocaleString(defaultLanguage, localizationId);
+		}
 		if (locString) {
 			el.innerText = locString;
-		}
-		else if (localizationStrings[defaultLanguage][localizationId] != null) {
-			el.innerText = localizationStrings[defaultLanguage][localizationId]; // fall back to english
 		}
 	}
 }
@@ -145,8 +150,7 @@ this.ChangeLanguage = function(newLanguage) {
 }
 
 function getString(id) {
-	var langStrings = localizationStrings[getEditorLanguage()];
-	return langStrings && langStrings[id];
+	return getLocaleString(getEditorLanguage(), id);
 }
 this.GetString = function(id) {
 	return getString(id);
@@ -171,7 +175,7 @@ this.GetStringOrFallback = function(id, englishFallback) {
 
 function localizationContains(id, text) { // TODO : rename to be more descriptive?
 	for (lang in localizationStrings) {
-		var locString = localizationStrings[lang][id];
+		var locString = getLocaleString(lang, id);
 		if (locString != null && locString.length > 0 && locString === text) {
 			return true;
 		}
@@ -208,7 +212,7 @@ this.ExportMissingEnglishStrings = function() {
 	for(var i = 0; i < elements.length; i++) {
 		var el = elements[i];
 		var localizationId = getLocalizationId(el);
-		if(!localizationStrings[defaultLanguage][localizationId])
+		if(!getLocaleString(defaultLanguage, localizationId))
 			englishStrings[localizationId] = el.innerText;
 	}
 	exportEnglishStringsDictionary(englishStrings);
@@ -219,7 +223,7 @@ this.ExportDynamicEnglishStrings = function() {
 }
 
 this.GetStringCount = function(langId) {
-	return Object.keys(localizationStrings[langId]).length;
+	return localizationStrings[langId] ? Object.keys(localizationStrings[langId]).length : 0;
 }
 
 initialize();

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -11,7 +11,7 @@ X get translation volunteers
 X how to handle multi-paragraph text (for now: lots of strings)
 X how to handle dynamic text
 X find instances of dynamic text
-- how to handle alt text & pladeholder text (other special cases)
+- how to handle alt text & placeholder text (other special cases)
 - dynamic text like "I'm a cat" "tea" and "Write your game's title here"
 */
 

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -160,7 +160,7 @@ function getStringOrFallback(id, englishFallback) {
 
 	var locString = getString(id);
 	if(!locString) {
-		locString = englishFallback;
+		locString = englishFallback || id;
 		unlocalizedDynamicStrings[id] = englishFallback; // record use of unlocalized strings
 	}
 	return locString;


### PR DESCRIPTION
- only access storage when initializing/saving, and use in-memory state elsewhere
- more robust guards/fallback behaviour for getting strings (doesn't assume strings exist for current language, and handles fallback as current language > default language > hard-coded fallback > id)

This fixes an issue where the editor ends up unrecoverable from a broken state as a result of something breaking the storage mechanism (unsure of the root cause). The "new game" button doesn't do anything in this state because it throws an exception when trying to get the string for the confirm popup. The more robust guards/fallbacks ensure that strings will always be retrieved regardless of validity, and using application state instead of directly reading from storage allows the editor to continue to working whether storage is broken or not.