### PR TITLE
fix: wrap storage mechanism and provide fallbacks to prevent storage errors from breaking editor

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -31,6 +31,7 @@
 		<script src="script/engine/bitsy.js"></script>
 
 		<!-- EDITOR SCRIPTS -->
+		<script src="script/store.js"></script>
 		<script src="script/util.js"></script>
 		<script src="script/icons.js"></script>
 		<script src="script/paint.js"></script>

--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -887,10 +887,7 @@ function start() {
 	}
 
 	// localization
-	if (urlFlags["lang"] != null) {
-		localStorage.editor_language = urlFlags["lang"]; // need to verify this is real language?
-	}
-	localization = new Localization();
+	localization = new Localization(urlFlags["lang"]);
 
 	//game canvas & context (also the map editor)
 	attachCanvas( document.getElementById("game") );

--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -887,6 +887,10 @@ function start() {
 
 	// localization
 	localization = new Localization(urlFlags["lang"]);
+	Store.init(function () {
+		// TODO: localize
+		window.alert('A storage error occurred: The editor will continue to work, but data may not be saved/loaded. Make sure to export a local copy after making changes, or your gamedata may be lost!');
+	});
 
 	//game canvas & context (also the map editor)
 	attachCanvas( document.getElementById("game") );

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -54,7 +54,7 @@ var initialize = function() { // why does this happen multiple times?
 		}
 	}
 
-	currentLanguage = initialLanguage || localStorage.editor_language;
+	currentLanguage = initialLanguage || localStorage.editor_language || defaultLanguage;
 
 	// console.log(localizationStrings);
 	// localize( getEditorLanguage() );

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -54,7 +54,7 @@ var initialize = function() { // why does this happen multiple times?
 		}
 	}
 
-	currentLanguage = initialLanguage || localStorage.editor_language || defaultLanguage;
+	currentLanguage = initialLanguage || Store.get('editor_language', defaultLanguage);
 
 	// console.log(localizationStrings);
 	// localize( getEditorLanguage() );
@@ -120,7 +120,7 @@ this.GetLanguage = function() {
 }
 
 function saveEditorLanguage(language) {
-	localStorage.editor_language = language;
+	Store.set('editor_language', language);
 }
 
 function getLanguageList() {

--- a/editor/script/localization.js
+++ b/editor/script/localization.js
@@ -15,7 +15,7 @@ X find instances of dynamic text
 - dynamic text like "I'm a cat" "tea" and "Write your game's title here"
 */
 
-function Localization() {
+function Localization(initialLanguage) {
 
 var self = this;
 
@@ -54,7 +54,7 @@ var initialize = function() { // why does this happen multiple times?
 		}
 	}
 
-	currentLanguage = localStorage.editor_language;
+	currentLanguage = initialLanguage || localStorage.editor_language;
 
 	// console.log(localizationStrings);
 	// localize( getEditorLanguage() );

--- a/editor/script/store.js
+++ b/editor/script/store.js
@@ -24,7 +24,7 @@ var Store = {
 	 * use to signal lack of storage to user
 	 */
 	init: function (onFirstError) {
-		this.onFirstError = function(err) {
+		this.onFirstError = function (err) {
 			this.error = true;
 			console.warn('Storage error', err);
 			if (onFirstError) onFirstError(err);
@@ -35,9 +35,7 @@ var Store = {
 			var testValue = 'test';
 			driver.setItem('_test_key_', testValue);
 			if (driver.getItem('_test_key_') !== testValue) {
-				throw('Storage access fails silently. This might be caused by ' +
-					  'a browser extension that blocks third-party cookies.'
-				);
+				throw new Error('Storage access fails silently. This might be caused by a browser extension that blocks third-party cookies.');
 			}
 			driver.removeItem('_test_key_');
 		} catch (err) {

--- a/editor/script/store.js
+++ b/editor/script/store.js
@@ -29,8 +29,14 @@ var Store = {
 		};
 		try {
 			// test that storage driver is available and working
-			this.driver.setItem('_test_key_', 'test');
-			this.driver.getItem('_test_key_');
+			this.driver = localStorage;
+			var testValue = 'test';
+			this.driver.setItem('_test_key_', testValue);
+			if (this.driver.getItem('_test_key_') !== testValue) {
+				throw('Storage access fails silently. This might be caused by ' +
+					  'a browser extension that blocks third-party cookies.'
+				);
+			}
 			this.driver.removeItem('_test_key_');
 		} catch (err) {
 			this.onFirstError(err);

--- a/editor/script/store.js
+++ b/editor/script/store.js
@@ -13,7 +13,9 @@
  */
 var Store = {
 	/** storage driver (must implement `getItem`, `setItem`, `removeItem`) */
-	driver: localStorage,
+	getDriver: function () {
+		return localStorage;
+	},
 	/** whether storage has failed */
 	error: false,
 	/**
@@ -29,15 +31,15 @@ var Store = {
 		};
 		try {
 			// test that storage driver is available and working
-			this.driver = localStorage;
+			var driver = this.getDriver();
 			var testValue = 'test';
-			this.driver.setItem('_test_key_', testValue);
-			if (this.driver.getItem('_test_key_') !== testValue) {
+			driver.setItem('_test_key_', testValue);
+			if (driver.getItem('_test_key_') !== testValue) {
 				throw('Storage access fails silently. This might be caused by ' +
 					  'a browser extension that blocks third-party cookies.'
 				);
 			}
-			this.driver.removeItem('_test_key_');
+			driver.removeItem('_test_key_');
 		} catch (err) {
 			this.onFirstError(err);
 		}
@@ -49,7 +51,7 @@ var Store = {
 	 */
 	get: function (name, fallback) {
 		try {
-			var value = this.driver.getItem(name);
+			var value = this.getDriver().getItem(name);
 			if (typeof value === 'string') {
 				try {
 					return JSON.parse(value);
@@ -71,9 +73,9 @@ var Store = {
 	set: function (name, value) {
 		try {
 			if (value === undefined) {
-				this.driver.removeItem(name);
+				this.getDriver().removeItem(name);
 			} else {
-				this.driver.setItem(name, JSON.stringify(value));
+				this.getDriver().setItem(name, JSON.stringify(value));
 			}
 		} catch (err) {
 			if (!this.error && this.onFirstError) {

--- a/editor/script/store.js
+++ b/editor/script/store.js
@@ -1,0 +1,78 @@
+/**
+ * ```js
+ * // call once
+ * Store.init(function onFirstError() {
+ * 	// called once when storage fails;
+ * 	// use to signal lack of storage to user
+ * 	window.alert('Storage is not working!');
+ * });
+ * // call as needed
+ * Store.get('key', 'fallback value');
+ * Store.set('key', 'new value');
+ * ```
+ */
+var Store = {
+	/** storage driver (must implement `getItem`, `setItem`, `removeItem`) */
+	driver: localStorage,
+	/** whether storage has failed */
+	error: false,
+	/**
+	 * Initializes storage mechanism
+	 * @param {(err: Error) => void} [onFirstError] called once when storage fails;
+	 * use to signal lack of storage to user
+	 */
+	init: function (onFirstError) {
+		this.onFirstError = function(err) {
+			this.error = true;
+			console.warn('Storage error', err);
+			if (onFirstError) onFirstError(err);
+		};
+		try {
+			// test that storage driver is available and working
+			this.driver.setItem('_test_key_', 'test');
+			this.driver.getItem('_test_key_');
+			this.driver.removeItem('_test_key_');
+		} catch (err) {
+			this.onFirstError(err);
+		}
+	},
+	/**
+	 * @param {string} name storage key
+	 * @param {any} [fallback] value returned if storage fails, or value for key is undefined
+	 * @returns {any} stored value for key, or fallback value
+	 */
+	get: function (name, fallback) {
+		try {
+			var value = this.driver.getItem(name);
+			if (typeof value === 'string') {
+				try {
+					return JSON.parse(value);
+				} catch {
+					return value;
+				}
+			}
+		} catch (err) {
+			if (!this.error && this.onFirstError) {
+				this.onFirstError(err);
+			}
+		}
+		return fallback;
+	},
+	/**
+	 * @param {string} name storage key
+	 * @param {any} [value] value to store (use `undefined` to clear)
+	 */
+	set: function (name, value) {
+		try {
+			if (value === undefined) {
+				this.driver.removeItem(name);
+			} else {
+				this.driver.setItem(name, JSON.stringify(value));
+			}
+		} catch (err) {
+			if (!this.error && this.onFirstError) {
+				this.onFirstError(err);
+			}
+		}
+	},
+};


### PR DESCRIPTION
- adds `store.js`, which provides `Store` global
  - `Store.get(name, fallback)`: retrieves stored value, using fallback if it is not set or if storage driver fails; stored values will automatically be parsed as JSON, and if the JSON parse fails, the raw string will be returned instead (this will safely handle migration from previous implementation)
  - `Store.set(name, value)`: stores value as stringified JSON
  - `Store.init(onFirstError)`: registers a callback which will be called the next time the storage driver fails, and immediately tests the storage driver
  - `Store.driver`: actual storage mechanism; not currently expecting this to change, but you could swap in e.g. `sessionStorage` since it has the same API as `localStorage` (a more truly agnostic implementation would need to handle an async drivers, but that seems overkill)
- replaces all direct `localStorage` use with `Store` use
- adds simple user-facing warning in the case that storage driver fails

This provides relatively graceful error-handling for all cases where the storage mechanism may fail. Previous PR (https://github.com/le-doux/bitsy/pull/119) fixed some specific side effects of broken storage in localization, but this is more robust and covers the entire editor.