### PR TITLE
fix: alt-clicking items not selecting them

### DIFF
--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -2034,11 +2034,11 @@ function editDrawingAtCoordinate(x,y) {
 		return;
 	}
 
-	var item = getItem(curRoom,x,y);
+	var itemObj = getItem(curRoom,x,y);
 	// bitsyLog(item, "editor");
-	if(item) {
+	if(itemObj) {
 		on_paint_item_ui_update();
-		paintTool.selectDrawing(item[item.id]);
+		paintTool.selectDrawing(item[itemObj.id]);
 		return;
 	}
 


### PR DESCRIPTION
`var item` shadowed `window.item`, which made `item[item.id]` always return `null` instead of actually selecting the right drawing when alt-clicking an item. this would put the editor in a recoverable but strange state where certain parts of the ui stopped working until a drawing was properly reloaded.