### PR TITLE
fix: replace various hard-coded constants with appropriate variables

### DIFF
--- a/editor/script/dialog_editor.js
+++ b/editor/script/dialog_editor.js
@@ -2803,7 +2803,8 @@ function DialogTool() {
 						var itemThumbnail = document.createElement("img");
 						span.appendChild(itemThumbnail);
 						itemThumbnail.id = "param_item_" + curValue;
-						itemThumbnail.style.width = "16px";
+						itemThumbnail.style.width = tilesize * 2 + "px";
+						itemThumbnail.style.height = tilesize * 2 + "px";
 						itemThumbnail.style.marginLeft = "4px";
 						thumbnailRenderer.Render(itemThumbnail.id, item[curValue], 0, itemThumbnail);
 					}

--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -878,8 +878,8 @@ function start() {
 
 	//
 	drawingThumbnailCanvas = document.createElement("canvas");
-	drawingThumbnailCanvas.width = 8 * scale;
-	drawingThumbnailCanvas.height = 8 * scale;
+	drawingThumbnailCanvas.width = tilesize * scale;
+	drawingThumbnailCanvas.height = tilesize * scale;
 	drawingThumbnailCtx = drawingThumbnailCanvas.getContext("2d");
 
 	// load custom font

--- a/editor/script/engine/bitsy.js
+++ b/editor/script/engine/bitsy.js
@@ -109,11 +109,11 @@ function clearGameData() {
 	textDirection = TextDirection.LeftToRight;
 }
 
-var width = 128;
-var height = 128;
 var scale = 4; //this is stupid but necessary
 var tilesize = 8;
 var mapsize = 16;
+var width = mapsize * tilesize;
+var height = mapsize * tilesize;
 
 var curRoom = "0";
 

--- a/editor/script/engine/bitsy.js
+++ b/editor/script/engine/bitsy.js
@@ -637,7 +637,7 @@ function isWallLeft() {
 }
 
 function isWallRight() {
-	return (player().x + 1 >= 16) || isWall( player().x + 1, player().y );
+	return (player().x + 1 >= mapsize) || isWall( player().x + 1, player().y );
 }
 
 function isWallUp() {
@@ -645,7 +645,7 @@ function isWallUp() {
 }
 
 function isWallDown() {
-	return (player().y + 1 >= 16) || isWall( player().x, player().y + 1 );
+	return (player().y + 1 >= mapsize) || isWall( player().x, player().y + 1 );
 }
 
 function isWall(x,y,roomId) {
@@ -1098,9 +1098,9 @@ function serializeDrawing(drwId) {
 }
 
 function isExitValid(e) {
-	var hasValidStartPos = e.x >= 0 && e.x < 16 && e.y >= 0 && e.y < 16;
+	var hasValidStartPos = e.x >= 0 && e.x < mapsize && e.y >= 0 && e.y < mapsize;
 	var hasDest = e.dest != null;
-	var hasValidRoomDest = (e.dest.room != null && e.dest.x >= 0 && e.dest.x < 16 && e.dest.y >= 0 && e.dest.y < 16);
+	var hasValidRoomDest = (e.dest.room != null && e.dest.x >= 0 && e.dest.x < mapsize && e.dest.y >= 0 && e.dest.y < mapsize);
 	return hasValidStartPos && hasDest && hasValidRoomDest;
 }
 

--- a/editor/script/engine/system.js
+++ b/editor/script/engine/system.js
@@ -243,12 +243,12 @@ var updateInterval = null;
 
 function initSystem() {
 	// temp hack for the editor? unless??
-	drawingBuffers[screenBufferId] = createDrawingBuffer(128, 128, scale);
+	drawingBuffers[screenBufferId] = createDrawingBuffer(width, height, scale);
 	drawingBuffers[textboxBufferId] = createDrawingBuffer(0, 0, textScale);
 }
 
 function loadGame(gameData, defaultFontData) {
-	drawingBuffers[screenBufferId] = createDrawingBuffer(128, 128, scale);
+	drawingBuffers[screenBufferId] = createDrawingBuffer(width, height, scale);
 	drawingBuffers[textboxBufferId] = createDrawingBuffer(0, 0, textScale);
 
 	document.addEventListener('keydown', input.onkeydown);

--- a/editor/script/engine/transition.js
+++ b/editor/script/engine/transition.js
@@ -77,8 +77,8 @@ var TransitionManager = function() {
 			}
 
 			bitsyDrawBegin(0);
-			for (var y = 0; y < 128; y++) {
-				for (var x = 0; x < 128; x++) {
+			for (var y = 0; y < height; y++) {
+				for (var x = 0; x < width; x++) {
 					var color = transitionEffects[curEffect].pixelEffectFunc(transitionStart, transitionEnd, x, y, (step / maxStep));
 					bitsyDrawPixel(color, x, y);
 				}
@@ -361,7 +361,7 @@ var TransitionManager = function() {
 	function createRoomPixelBuffer(room) {
 		var pixelBuffer = [];
 
-		for (var i = 0; i < 128 * 128; i++) {
+		for (var i = 0; i < width * height; i++) {
 			pixelBuffer.push(tileColorStartIndex);
 		}
 
@@ -371,7 +371,7 @@ var TransitionManager = function() {
 			for (var y = 0; y < tilesize; y++) {
 				for (var x = 0; x < tilesize; x++) {
 					var color = tileColorStartIndex + (frameData[y][x] === 1 ? colorIndex : 0);
-					pixelBuffer[(((ty * tilesize) + y) * 128) + ((tx * tilesize) + x)] = color;
+					pixelBuffer[(((ty * tilesize) + y) * width) + ((tx * tilesize) + x)] = color;
 				}
 			}
 		}
@@ -435,11 +435,11 @@ var TransitionManager = function() {
 
 // todo : is this wrapper still useful?
 var PostProcessImage = function(imageData) {
-	this.Width = 128;
-	this.Height = 128;
+	this.Width = width;
+	this.Height = height;
 
 	this.GetPixel = function(x, y) {
-		return imageData[(y * 128) + x];
+		return imageData[(y * width) + x];
 	};
 
 	this.GetData = function() {

--- a/editor/script/gif.js
+++ b/editor/script/gif.js
@@ -505,11 +505,7 @@ function trailer(gifArr) {
 
 //refactor and rename?
 function colorTableSizeThatFitsPalette(colors) {
-	var size = 0;
-	while (colors.length > Math.pow(2,size+1)) {
-		size++;
-	}
-	return size;
+	return Math.max(0, Math.ceil(Math.log2(colors.length))-1);
 }
 
 function padPalette(colors, size) {

--- a/editor/script/paint.js
+++ b/editor/script/paint.js
@@ -128,8 +128,8 @@ function PaintTool(canvas, roomTool) {
 		}
 
 		//draw pixels
-		for (var x = 0; x < 8; x++) {
-			for (var y = 0; y < 8; y++) {
+		for (var x = 0; x < tilesize; x++) {
+			for (var y = 0; y < tilesize; y++) {
 				// draw alternate frame
 				if (self.isCurDrawingAnimated && curDrawingAltFrameData()[y][x] === 1) {
 					ctx.globalAlpha = 0.3;

--- a/editor/script/thumbnail.js
+++ b/editor/script/thumbnail.js
@@ -259,7 +259,7 @@ function createPaletteThumbnailRenderer() {
 		return palette[id];
 	}
 
-	var getHexPalette = function(pal) {
+	var getHexPaletteBase = function(pal) {
 		var hexPalette = [];
 
 		if (pal.id in palette) {
@@ -275,9 +275,14 @@ function createPaletteThumbnailRenderer() {
 		return hexPalette;
 	}
 
+	// always include black for border, but not in palette itself
+	var getHexPalette = function(pal) {
+		return getHexPaletteBase(pal).concat('000000');
+	}
+
 	var onRender = function(pal, ctx, options) {
 		if (pal.id in palette) {
-			var hexPalette = getHexPalette(pal);
+			var hexPalette = getHexPaletteBase(pal);
 
 			ctx.fillStyle = "black";
 			ctx.fillRect(0, 0, 8 * scale, 8 * scale);

--- a/editor/script/thumbnail.js
+++ b/editor/script/thumbnail.js
@@ -4,8 +4,8 @@ function ThumbnailRenderer() {
 
 	var drawingThumbnailCanvas, drawingThumbnailCtx;
 	drawingThumbnailCanvas = document.createElement("canvas");
-	drawingThumbnailCanvas.width = 8 * scale; // TODO: scale constants need to be contained somewhere
-	drawingThumbnailCanvas.height = 8 * scale;
+	drawingThumbnailCanvas.width = tilesize * scale; // TODO: scale constants need to be contained somewhere
+	drawingThumbnailCanvas.height = tilesize * scale;
 	drawingThumbnailCtx = drawingThumbnailCanvas.getContext("2d");
 
 	var thumbnailRenderEncoders = {};
@@ -57,18 +57,18 @@ function ThumbnailRenderer() {
 
 		if( isAnimated || frameIndex == 0 ) {
 			thumbnailDraw(drawing, drawingThumbnailCtx, 0, 0, 0 /*frameIndex*/);
-			drawingFrameData.push( drawingThumbnailCtx.getImageData(0,0,8*scale,8*scale).data );
+			drawingFrameData.push( drawingThumbnailCtx.getImageData(0,0,tilesize*scale,tilesize*scale).data );
 		}
 		if( isAnimated || frameIndex == 1 ) {
 			thumbnailDraw(drawing, drawingThumbnailCtx, 0, 0, 1 /*frameIndex*/);
-			drawingFrameData.push( drawingThumbnailCtx.getImageData(0,0,8*scale,8*scale).data );
+			drawingFrameData.push( drawingThumbnailCtx.getImageData(0,0,tilesize*scale,tilesize*scale).data );
 		}
 
 		// create encoder
 		var gifData = {
 			frames: drawingFrameData,
-			width: 8*scale,
-			height: 8*scale,
+			width: tilesize*scale,
+			height: tilesize*scale,
 			palette: hexPalette,
 			loops: 0,
 			delay: animationTime / 10 // TODO why divide by 10???
@@ -117,8 +117,8 @@ function ThumbnailRenderer() {
 
 function ThumbnailRendererBase(getRenderable, getHexPalette, onRender) {
 	var renderCanvas = document.createElement("canvas");
-	renderCanvas.width = 8 * scale; // TODO: scale constants need to be contained somewhere
-	renderCanvas.height = 8 * scale;
+	renderCanvas.width = tilesize * scale; // TODO: scale constants need to be contained somewhere
+	renderCanvas.height = tilesize * scale;
 
 	var renderCtx = renderCanvas.getContext("2d");
 
@@ -227,7 +227,7 @@ function createDrawingThumbnailRenderer(source) {
 
 					if (renderedImg) {
 						ctx.drawImage(renderedImg, 0, 0, tilesize * scale, tilesize * scale);
-						renderFrames.push(ctx.getImageData(0, 0, 8 * scale, 8 * scale).data);
+						renderFrames.push(ctx.getImageData(0, 0, tilesize * scale, tilesize * scale).data);
 					}
 					else {
 						bitsyLog("oh no! image render for thumbnail failed", "editor");
@@ -281,23 +281,26 @@ function createPaletteThumbnailRenderer() {
 	}
 
 	var onRender = function(pal, ctx, options) {
+		var padding = 0.125;
+		var fillSize = 1 - padding*2;
 		if (pal.id in palette) {
 			var hexPalette = getHexPaletteBase(pal);
+			var bar = (1 / 3) * fillSize;
 
 			ctx.fillStyle = "black";
-			ctx.fillRect(0, 0, 8 * scale, 8 * scale);
+			ctx.fillRect(0, 0, tilesize * scale, tilesize * scale);
 
 			ctx.fillStyle = "#" + hexPalette[0];
-			ctx.fillRect(1 * scale, 1 * scale, 6 * scale, 2 * scale);
+			ctx.fillRect(tilesize * scale * padding, tilesize * scale * (padding + 0 * bar), tilesize * scale * fillSize, tilesize * scale * bar);
 
 			ctx.fillStyle = "#" + hexPalette[1];
-			ctx.fillRect(1 * scale, 3 * scale, 6 * scale, 2 * scale);
+			ctx.fillRect(tilesize * scale * padding, tilesize * scale * (padding + 1 * bar), tilesize * scale * fillSize, tilesize * scale * bar);
 
 			ctx.fillStyle = "#" + hexPalette[2];
-			ctx.fillRect(1 * scale, 5 * scale, 6 * scale, 2 * scale);
+			ctx.fillRect(tilesize * scale * padding, tilesize * scale * (padding + 2 * bar), tilesize * scale * fillSize, tilesize * scale * bar);
 		}
 
-		return [ctx.getImageData(0, 0, 8 * scale, 8 * scale).data];
+		return [ctx.getImageData(0, 0, tilesize * scale, tilesize * scale).data];
 	}
 
 	return new ThumbnailRendererBase(getRenderable, getHexPalette, onRender);
@@ -325,8 +328,8 @@ function createRoomThumbnailRenderer() {
 	}
 
 	function onRender(r, ctx, options) {
-		var roomRenderSize = 8 * scale;
-		var tileRenderSize = roomRenderSize / 16;
+		var roomRenderSize = tilesize * scale;
+		var tileRenderSize = roomRenderSize / mapsize;
 
 		if (r.id in room) {
 			var roomId = r.id;
@@ -338,8 +341,8 @@ function createRoomThumbnailRenderer() {
 			ctx.fillRect(0, 0, roomRenderSize, roomRenderSize);
 
 			// tiles
-			for (var ry = 0; ry < 16; ry++) {
-				for (var rx = 0; rx < 16; rx++) {
+			for (var ry = 0; ry < mapsize; ry++) {
+				for (var rx = 0; rx < mapsize; rx++) {
 					var tileId = r.tilemap[ry][rx];
 
 					if (tileId != "0" && (tileId in tile)) {

--- a/editor/script/thumbnail.js
+++ b/editor/script/thumbnail.js
@@ -285,19 +285,15 @@ function createPaletteThumbnailRenderer() {
 		var fillSize = 1 - padding*2;
 		if (pal.id in palette) {
 			var hexPalette = getHexPaletteBase(pal);
-			var bar = (1 / 3) * fillSize;
+			var bar = (1 / hexPalette.length) * fillSize;
 
 			ctx.fillStyle = "black";
 			ctx.fillRect(0, 0, tilesize * scale, tilesize * scale);
 
-			ctx.fillStyle = "#" + hexPalette[0];
-			ctx.fillRect(tilesize * scale * padding, tilesize * scale * (padding + 0 * bar), tilesize * scale * fillSize, tilesize * scale * bar);
-
-			ctx.fillStyle = "#" + hexPalette[1];
-			ctx.fillRect(tilesize * scale * padding, tilesize * scale * (padding + 1 * bar), tilesize * scale * fillSize, tilesize * scale * bar);
-
-			ctx.fillStyle = "#" + hexPalette[2];
-			ctx.fillRect(tilesize * scale * padding, tilesize * scale * (padding + 2 * bar), tilesize * scale * fillSize, tilesize * scale * bar);
+			for (i in hexPalette) {
+				ctx.fillStyle = "#" + hexPalette[i];
+				ctx.fillRect(tilesize * scale * padding, tilesize * scale * (padding + i * bar), tilesize * scale * fillSize, tilesize * scale * bar);
+			}
 		}
 
 		return [ctx.getImageData(0, 0, tilesize * scale, tilesize * scale).data];


### PR DESCRIPTION
i put in some time on borksy recently to port the bitsy HD template to modern bitsy, and while doing so noticed a whole bunch of different places where manual changes were needed that shouldn't have been due to the original code being hard-coded instead of generic.

all bitsy HD functionally does is change the resolution of tiles, but keeping it up to date is significantly more effort than just changing `tilesize = 8` to `tilesize = 16` right now. most of these changes will simplify that going forward.

there's only one user-facing change for bitsy itself, which is that the palette thumbnail logic has been simplified to be calculated based on the thumbnail size/number of palette colours instead of three hard-coded draw calls, which means "extended" palettes will actually show up in the thumbnail (if this is undesired, a `.slice(0,3)` could be added to restrict it to just the original 3 colours, but seemed like a harmless improvement to me).