### PR TITLE
feat: allow editor panels to be resized + better use screen real estate

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -619,7 +619,7 @@
 					</div>
 
 					<div class="bitsy-card-main">
-						<form id="paintModeRadio" style="margin-bottom: 5px;">
+						<form id="paintModeRadio" class="bitsy-menu-group">
 							<input type="radio" name="paint mode" value="avatar" onclick="on_paint_avatar();" id="paintOptionAvatar" checked>
 							<label title="edit the avatar: the player's character" for="paintOptionAvatar" class="left">
 								<span class="bitsy_icon icon_space_right">avatar</span>

--- a/editor/style/bitsyEditorStyle.css
+++ b/editor/style/bitsyEditorStyle.css
@@ -232,6 +232,7 @@ input[type=checkbox] + label:hover {
 	max-height: 100%;
 	overflow-y: auto;
 	overflow-x: hidden;
+	resize: both;
 	display: flex;
 	flex-direction: column;
 }
@@ -289,6 +290,10 @@ input[type=checkbox] + label:hover {
 
 	.bitsy-card .bitsy-card-main {
 		width: calc(100% - (2 * var(--bitsy-space-m)));
+	}
+
+	.bitsy-card-main {
+		resize: none;
 	}
 }
 

--- a/editor/style/bitsyEditorStyle.css
+++ b/editor/style/bitsyEditorStyle.css
@@ -232,6 +232,8 @@ input[type=checkbox] + label:hover {
 	max-height: 100%;
 	overflow-y: auto;
 	overflow-x: hidden;
+	display: flex;
+	flex-direction: column;
 }
 
 .bitsy-card-xs .bitsy-card-main {

--- a/editor/style/paintToolStyle.css
+++ b/editor/style/paintToolStyle.css
@@ -1,7 +1,3 @@
-#paintModeRadio {
-	display: flex;
-}
-
 #animationOuter {
 	margin-top: var(--bitsy-space-s);
 }


### PR DESCRIPTION
this is more of a feature suggestion than a bugfix, but it's one that comes from this feature having existed in the past on certain panels (e.g. find tool) and seeing a number of folks complain about it going missing. it's a bit of a quick and dirty fix, but it's unobtrusive as well, the resize tab being easily ignored if you're comfortable with the preset panel sizes

example of how this can be used to give yourself more space for the find panel and dialog while still needing to see the room/paint tool, but not as prominently

![image](https://user-images.githubusercontent.com/6496840/147870906-8436cc7b-0760-453c-972f-3b0fcc1b5100.png)

note that it's disabled on mobile due to the scroll-snapping css that's being used as a mobile treatment (resize isn't particularly good ux on mobile anyway)
