### PR TITLE
fix: rainbow text effect letters not showing up when dialog completed early

### DIFF
--- a/editor/script/engine/dialog.js
+++ b/editor/script/engine/dialog.js
@@ -874,9 +874,12 @@ var ArabicHandler = function() {
 /* NEW TEXT EFFECTS */
 var TextEffects = {};
 
+function positiveModulo(number, divisor) {
+	return ((number % divisor) + divisor) % divisor;
+}
 var RainbowEffect = function() {
 	this.DoEffect = function(char, time) {
-		char.color = rainbowColorStartIndex + Math.floor(((time / 100) - char.col * 0.5) % rainbowColorCount);
+		char.color = rainbowColorStartIndex + Math.floor(positiveModulo((time / 100) - char.col * 0.5, rainbowColorCount));
 	}
 };
 TextEffects["rbw"] = new RainbowEffect();


### PR DESCRIPTION
because the logic here is `(time - position) % count`, with `time` potentially be zero and `position` always being positive, you can end up with e.g. `-11 % 10`, which in JS results in `-1`, which is an invalid palette index. an alternate modulo fn is added which will ensure a positive number following the expected pattern (e.g. `positiveModule(-11, 10)` will give `9`)

example of what this bug looks like
![image](https://user-images.githubusercontent.com/6496840/147871348-f3b997f8-605a-4fd9-a09d-dc19e9736341.png)
vs what it should look like
![image](https://user-images.githubusercontent.com/6496840/147871350-fb8e4f64-51ee-4808-be68-182ea557ba8d.png)
