### PR TITLE
fix: room preview not updating when changing current palette

### DIFF
--- a/editor/script/room.js
+++ b/editor/script/room.js
@@ -292,6 +292,7 @@ function RoomTool(canvas) {
 	}
 
 	events.Listen("palette_change", function(event) {
+		initRoom(curRoom);
 		self.drawEditMap();
 	});
 } // RoomTool()


### PR DESCRIPTION
fixes issue where room preview shows old palette colours until changing rooms