### PR TITLE
Fix exported games breaking due to CRLF in template

### DIFF
--- a/dev/resource_packager.js
+++ b/dev/resource_packager.js
@@ -1,5 +1,7 @@
 var fs = require("fs");
 
+/* NOTE: this is made to deal with text files. if you add binaries to it,
+ * it WILL break! */
 var resourceFiles = [
 	/* localization */
 	"resources/localization.tsv",
@@ -40,6 +42,11 @@ for (var i = 0; i < resourceFiles.length; i++) {
 	var path = resourceFiles[i];
 	var fileName = getFileName(path);
 	var result = fs.readFileSync(path, "utf8");
+	/* if this program is checked out with git on Windows, our text fiels
+	 * will use CR LF lines. we try to deal with this in places where it
+	 * may break, but we should really just make sure the resource files
+	 * consistently only have LF. */
+	result = result.replaceAll(/\r\n/g, "\n");
 	resourcePackage[fileName] = result;
 }
 

--- a/editor/script/exporter.js
+++ b/editor/script/exporter.js
@@ -58,6 +58,10 @@ function unescapeSpecialCharacters(str) {
 this.importGame = function( html ) {
 	bitsyLog("IMPORT!!!", "editor");
 
+	// fix a regression with 7.11 where the template data in resources included
+	// CRLFs
+	html = html.replace(/\r\n/g, "\n")
+
 	// IMPORT : new style
 	var scriptStart = '<script type="bitsyGameData" id="exportedGameData">\n';
 	var scriptEnd = '</script>';


### PR DESCRIPTION
Commit 7020c5c pushed a new updated packed version of the resources
files using editor/script/generated/resources.js. This script copies
Unicode data from files directly into a JS object. However, git will
check out files differently based on whether the user is on a Windows
machine, adjusting the newline format of text files automatically. When
the script was run on a Windows machine, it inserted CRLF newlines
instead of LF newlines into every file, including the template for
exported games. The games themselves worked fine when run in a browser,
but the editor's import tool depended on specific strings (including
newline characters) to find the game data.

This tool patches both the import tool and the resource packer to
replace CRLF newlines with regular LF ones. The import tool had to be
patched in order to load any games exported with Bitsy 7.11, and the
packer was changed in order to prevent any future problems.