### PR TITLE
sanitize branch name

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           path: editor
           retention-days: 7
-          name: ${{ steps.name.outputs..ARTIFACT_NAME }}
+          name: ${{ steps.name.outputs.ARTIFACT_NAME }}

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -26,9 +26,10 @@ jobs:
 
       # upload
       - name: sanitize branch name
-        run: echo ::set-env name=ARTIFACT_NAME::$(echo ${{ github.head_ref }} | tr "/" "_")
+        id: name
+        run: echo ::set-output name=ARTIFACT_NAME::$(echo ${{ github.head_ref }} | tr "/" "_")
       - uses: actions/upload-artifact@v3
         with:
           path: editor
           retention-days: 7
-          name: ${{ env.ARTIFACT_NAME }}
+          name: ${{ steps.name.outputs..ARTIFACT_NAME }}

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -25,8 +25,10 @@ jobs:
         working-directory: docs
 
       # upload
+      - name: sanitize branch name
+        run: echo ::set-env name=ARTIFACT_NAME::$(echo ${{ github.head_ref }} | tr "/" "_")
       - uses: actions/upload-artifact@v3
         with:
           path: editor
           retention-days: 7
-          name: ${{ github.head_ref }}
+          name: ${{ env.ARTIFACT_NAME }}


### PR DESCRIPTION
## Description

adds a sanitize step to the branch workflow; this should fix the issue where slashes in branch names (e.g. from dependabot) cause the check to fail

