### PR TITLE
Fix room tool not updating when changing color palette

### DIFF
--- a/editor/script/palette.js
+++ b/editor/script/palette.js
@@ -85,6 +85,9 @@ function PaletteTool(colorPicker,labelIds,nameFieldId) {
 
 		if( event.isMouseUp && !events.IsEventActive("game_data_change") ) {
 			events.Raise("palette_change"); // TODO -- try including isMouseUp and see if we can update more stuff live
+			if (roomTool) {
+				roomTool.select(roomTool.getSelected());
+			}
 		}
 	});
 


### PR DESCRIPTION
Currently the room tool does not update when changing the color palette. This update fixes that issue #192

I attempted to add an event listener to the room tool: events.Listen("palette_change", function(event) {...}, but there didn't seem to be an obvious way to redraw the room. This was the least intrusive fix I came up with, and it replicates the way the paint tool does it. If a different method is desired any feedback is appreciated, I don't mind investigating other ways of implementing the fix.