### PR TITLE
Fix y-coordinate typo in createExitData

### DIFF
--- a/editor/script/engine/world.js
+++ b/editor/script/engine/world.js
@@ -422,7 +422,7 @@ function createRoomData(id) {
 function createExitData(x, y, destRoom, destX, destY, transition, dlg) {
 	return {
 		x: x,
-		y: x,
+		y: y,
 		dest: {
 			room: destRoom,
 			x: destX,


### PR DESCRIPTION
Commit [7488171](https://github.com/le-doux/bitsy/commit/74881711335ef6b92238d53f458b6fa6ac4ecf8c) in part addressed issue [#171](https://github.com/le-doux/bitsy/issues/171). In this fix, function ‘createExitData’ was made with a typo and exits are now being created with both coordinates pointing to x. 
 
 This PR only corrects the typo on createExitData so y-coordinate is assigned properly.
