### PR TITLE
Add regenerate button for blips

### DIFF
--- a/editor/script/tools/blip.js
+++ b/editor/script/tools/blip.js
@@ -83,7 +83,6 @@ function makeBlipTool() {
 
 		function generate() {
 			var curBlip = blip[selectedId];
-			curBlip.name = CreateDefaultName(blipNames[curGenerator], blip);
 
 			switch (curGenerator) {
 				case BlipGenerator.PICKUP:
@@ -513,6 +512,15 @@ function makeBlipTool() {
 				}
 			});
 
+			tool.menu.push({
+				control: "button",
+				icon: "loop",
+				description: "Regenerate blip",
+				onclick : function(e) {
+					generate()
+				},
+			});
+
 			tool.menu.pop({ control: "group" });
 		};
 
@@ -538,6 +546,7 @@ function makeBlipTool() {
 			}
 
 			selectedId = nextId;
+			blip[selectedId].name = CreateDefaultName(blipNames[curGenerator], blip);
 			generate();
 		};
 


### PR DESCRIPTION
## Description

Closes #233 

Adds a regenerate button to the blip tool. This removes the need to create new files just to generate new blips, improving usability.

### Notes

* Loop icon used as the regenerate button
* Regenerating a blip does not modify its name
* New file name generation still works as it did before, with new files having the name "generator #" with incrementing numbers

## Screenshots

<img width="281" alt="Screen Shot 2023-11-06 at 9 42 57 PM" src="https://github.com/le-doux/bitsy/assets/41334074/6ec5b117-5e0a-4228-b8c2-65645295b8fe">
