### PR TITLE
revert "make sure ClearCache() deletes tile memory"

### DIFF
--- a/editor/script/engine/renderer.js
+++ b/editor/script/engine/renderer.js
@@ -135,7 +135,12 @@ this.GetFrameCount = function(drawingId) {
 // todo : forceReset option is hacky?
 this.ClearCache = function(forceReset) {
 	if (forceReset === undefined || forceReset === true) {
-		bitsy.deleteAllTiles();
+		for (var cacheId in drawingCache.render) {
+			var tiles = drawingCache.render[cacheId];
+			for (var i = 0; i < tiles.length; i++) {
+				bitsy.delete(tiles[i]);
+			}
+		}
 	}
 
 	drawingCache.render = {};

--- a/editor/script/system/system.js
+++ b/editor/script/system/system.js
@@ -637,15 +637,6 @@ function BitsySystem(name) {
 		self._free(tile);
 	};
 
-	this.deleteAllTiles = function() {
-		if (tilePoolStart != null) {
-			for (var i = 0; i < tilePoolSize; i++) {
-				var tile = tilePoolStart + i;
-				this.delete(tile);
-			}
-		}
-	};
-
 	this.fill = function(block, value) {
 		var len = memory.blocks[block].length;
 		for (var i = 0; i < len; i++) {


### PR DESCRIPTION
my ClearCache change broke the editor... I guess the room-reset code (that gets called when sprite edits are made) is too complex for me to reason about. (I added some logging to ClearCache (after making this commit) and noticed that ClearCache is called 4 separate times every time you make an edit in the sprite Paint tool. it's not quite once per tile but it seems odd)

stepping back, I think that the room should not reset itself on every stroke of the Paint tool. but I'd rather not break anything else so I'm not going to dig into it on my own.

anyway, my bad! this commit undoes my previous commit, fixing #250

but now #230 is back, and I don't know how to fix it
