### PR TITLE
Fix graphical glitch when unpausing the game: issue #266

### DIFF
--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -1420,6 +1420,15 @@ function on_edit_mode() {
 	renderer.ClearCache();
 	roomTool.renderer.ClearCache();
 
+	// A hacky way to fix graphical issues when unpausing.
+	//refreshGameData()
+	var gameDataNoFonts = serializeWorld(true);
+	Store.set("game_data", gameDataNoFonts)
+	// TODO: find out why this works; a bug in the game_data store? maybe?
+	// alternatively, refreshGameData() could be used here
+	// the above is a subsection of the refreshGameData() function which
+	// could help with further narrowing down
+
 	// reparse world to reset any changes from gameplay
 	var gamedataStorage = Store.get("game_data");
 	loadWorldFromGameData(gamedataStorage);

--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -1427,7 +1427,7 @@ function on_edit_mode() {
 	// TODO: find out why this works; a bug in the game_data store? maybe?
 	// alternatively, refreshGameData() could be used here
 	// the above is a subsection of the refreshGameData() function which
-	// could help with further narrowing down
+	// could help with further narrowing down the bug
 
 	// reparse world to reset any changes from gameplay
 	var gamedataStorage = Store.get("game_data");

--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -1421,6 +1421,7 @@ function on_edit_mode() {
 	roomTool.renderer.ClearCache();
 
 	// A hacky way to fix graphical issues when unpausing.
+	// reload and store the game data
 	//refreshGameData()
 	var gameDataNoFonts = serializeWorld(true);
 	Store.set("game_data", gameDataNoFonts)


### PR DESCRIPTION
## Description

This PR fixes the graphical glitch described in #266.
It changes the function `on_edit_mode()` so it reloads game data.
Call Trace:  `user clicks pause / play button` -> `togglePlayMode(event)` -> `on_edit_mode()`

## Screenshots

Current behaviour
![before the patch](https://github.com/le-doux/bitsy/assets/154544638/8f1a3e4c-2596-486f-bc44-72b0e9450b79)

Patched behaviour
![my changes](https://github.com/le-doux/bitsy/assets/154544638/583b311e-3164-4eb0-97bf-e936774f7625)





