### PR TITLE
Duplicate tag on save/load fix

### DIFF
--- a/editor/script/engine/world.js
+++ b/editor/script/engine/world.js
@@ -895,14 +895,15 @@ function parseFontData(parseState, world) {
 	var localFontData = lines[i];
 	i++;
 
-	while (i < lines.length && lines[i] != "") {
+	// Check for closing script tag to stop tag duplication on save/load html
+	while (i < lines.length && lines[i] != "</script>") {
 		localFontData += "\n" + lines[i];
 		i++;
 	}
-
+	
 	var localFontFilename = localFontName + fontManager.GetExtension();
 	fontManager.AddResource( localFontFilename, localFontData );
-
+	
 	return i;
 }
 

--- a/editor/script/engine/world.js
+++ b/editor/script/engine/world.js
@@ -896,7 +896,7 @@ function parseFontData(parseState, world) {
 	i++;
 
 	// Check for closing script tag to stop tag duplication on save/load html
-	while (i < lines.length && lines[i] != "</script>") {
+	while (i < lines.length && lines[i] != "</script>" && lines[i] != "") {
 		localFontData += "\n" + lines[i];
 		i++;
 	}


### PR DESCRIPTION
Check for closing `</script>` tag when parsing font to avoid tag duplication

## Description

Relating to issue #271 
- Saving and loading `.html` file would cause duplicate `</script>` tags at end of font data.
- Added check for closing `</script>` tag when parsing font data on load.

Font data was being overridden on load to contain all data past the opening script tag but not checking for the closing one.
